### PR TITLE
[FIX]: incomplete password check

### DIFF
--- a/src/server/controllers/user.controller.js
+++ b/src/server/controllers/user.controller.js
@@ -5,7 +5,7 @@ const generateToken = require("../utils/generateToken");
 const verifyPasswordStrenght = (password) => {
   if (password.length < 6) return 'Password is too short';
   
-  const regex = /^(?=.*[A-Z])(?=.*&).+$/;
+  const regex = /^(?=.*[A-Z])(?=.*[\W_]).+$/;
   if (!regex.test(password)) return 'Password must contain at least one uppercase letter and one symbol';
 
   return true;


### PR DESCRIPTION
### 📄 **Pull Request Description**
Password verification when registering would fail when using a password with a special as long as it wasn't an amperstand `&`, this PR fixes the issue by altering the regex pattern.

---

### 📝 **Major Changes**
None

---

### ✅ **Type of Modifications**
- 🐛 Bug Fix  

---

### 🔗 **Related Issues**
None

---

### 📊 **Testing Steps**
<!-- Outline how your changes can be tested. Include steps, environments, or edge cases considered. -->
1. Go to the auth page
2. Select register
3. Create an account with a password without using `&` in it
  - it should only accept passwords with 6 characters, an uppercase and lowercase letter & special character

---

### 🛑 **Checklist Before Merging**
- [x] Code follows the project's coding standards.
- [x] Appropriate tests have been added or updated.
- [ ] Documentation updated where necessary.
- [ ] PR title and description are clear and concise.
- [x] All checks pass (CI/CD, linting).

